### PR TITLE
Basic support for filling chests random upon opening them

### DIFF
--- a/src/main/java/com/randude14/hungergames/Config.java
+++ b/src/main/java/com/randude14/hungergames/Config.java
@@ -14,6 +14,7 @@ import org.bukkit.material.MaterialData;
 
 import static com.randude14.hungergames.Defaults.Message.*;
 import static com.randude14.hungergames.Defaults.Config.*;
+import java.util.*;
 
 public class Config {
 	private static final Plugin plugin = Plugin.getInstance();
@@ -299,7 +300,7 @@ public class Config {
 	public static List<String> getItemSets(){
 	    ConfigurationSection section = plugin.getConfig().getConfigurationSection("itemsets");
 	    if(section == null) return Collections.emptyList();
-	    List<String> list = (List<String>) section.getKeys(false);
+	    List<String> list = new ArrayList<String>(section.getKeys(false));
 	    return (List<String>) ((list == null) ? Collections.emptyList() : list);
 	}
 	

--- a/src/main/java/com/randude14/hungergames/Plugin.java
+++ b/src/main/java/com/randude14/hungergames/Plugin.java
@@ -93,7 +93,7 @@ public class Plugin extends JavaPlugin implements Listener {
 		pm.registerEvents(manager, this);
 		pm.registerEvents(new BlockListener(), this);
 		pm.registerEvents(new CommandListener(), this);
-		pm.registerEvents(new TeleportListener(), this);
+		//pm.registerEvents(new TeleportListener(), this);
 		if (!new File(getDataFolder(), "config.yml").exists()) {
 		    info("config.yml not found. Saving defaults.");
 		    saveDefaultConfig();
@@ -480,7 +480,7 @@ public class Plugin extends JavaPlugin implements Listener {
 		Location loc = frozenPlayers.get(player);
 		if (!equals(at, loc)) {
 			player.teleport(loc);
-		}
+		} 
 
 	}
 
@@ -737,7 +737,7 @@ public class Plugin extends JavaPlugin implements Listener {
 		int num = 3 + rand.nextInt(8);
 		Map<ItemStack, Float> itemMap = Config
 				.getAllChestLootWithGlobal(itemsets);
-		List<ItemStack> items = (List<ItemStack>) itemMap.keySet();
+		List<ItemStack> items = new ArrayList<ItemStack>(itemMap.keySet());
 		for (int cntr = 0; cntr < num; cntr++) {
 			int index = rand.nextInt(inv.getSize());
 			if (inv.getItem(index) != null) {

--- a/src/main/java/com/randude14/hungergames/Plugin.java
+++ b/src/main/java/com/randude14/hungergames/Plugin.java
@@ -52,6 +52,8 @@ import com.randude14.hungergames.register.Economy;
 import com.randude14.hungergames.register.Permission;
 import com.randude14.hungergames.register.VaultPermission;
 import com.randude14.hungergames.utils.FileUtils;
+import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.inventory.InventoryType;
 
 public class Plugin extends JavaPlugin implements Listener {
 	public static final String CMD_ADMIN = "hga";
@@ -692,6 +694,20 @@ public class Plugin extends JavaPlugin implements Listener {
 
 	    }
 	}
+        
+  	@EventHandler(priority = EventPriority.MONITOR)
+	public void inventoryOpen(InventoryOpenEvent event) {
+		if(event.getInventory().getType() != InventoryType.CHEST) {
+                    return;
+                }
+                Player player = (Player)event.getPlayer();
+                HungerGame game = GameManager.getSession(player);
+                if(game == null) {
+                    return;
+                }
+                
+                game.fillInventory(event.getInventory());
+	}
 
 	public static boolean hasInventoryBeenCleared(Player player) {
 		PlayerInventory inventory = player.getInventory();
@@ -711,12 +727,12 @@ public class Plugin extends JavaPlugin implements Listener {
 		return true;
 	}
 
-	public static void fillChest(Chest chest, List<String> itemsets) {
+	public static void fillChest(Inventory inv, List<String> itemsets) {
 		if (globalChestLoot.isEmpty()
 				&& (itemsets == null || itemsets.isEmpty())) {
 			return;
 		}
-		Inventory inv = chest.getInventory();
+		
 		inv.clear();
 		int num = 3 + rand.nextInt(8);
 		Map<ItemStack, Float> itemMap = Config

--- a/src/main/java/com/randude14/hungergames/games/HungerGame.java
+++ b/src/main/java/com/randude14/hungergames/games/HungerGame.java
@@ -23,6 +23,7 @@ import com.randude14.hungergames.GameManager;
 import com.randude14.hungergames.Plugin;
 import com.randude14.hungergames.api.event.*;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
 
 import org.bukkit.inventory.ItemStack;
 
@@ -42,7 +43,7 @@ public class HungerGame implements Comparable<HungerGame> {
 	private boolean isCounting;
 	private boolean isPaused;
 	private boolean enabled;
-        private List<Inventory> randomChests;
+        private List<InventoryHolder> randomChests;
 
 	public HungerGame(String name) {
 		this.name = name;
@@ -58,7 +59,7 @@ public class HungerGame implements Comparable<HungerGame> {
 		setup = null;
 		itemsets = new ArrayList<String>();
 		enabled = true;
-                randomChests = new ArrayList<Inventory>();
+                randomChests = new ArrayList<InventoryHolder>();
 	}
 
 	public HungerGame(String name, String setup) {
@@ -98,6 +99,11 @@ public class HungerGame implements Comparable<HungerGame> {
 			}
 
 		}
+                
+                if(section.isList("itemsets")) {
+                    itemsets = section.getStringList("itemsets");
+                }
+                
 		enabled = section.getBoolean("enabled", Boolean.TRUE);
 		spawn = Plugin.parseToLoc(section.getString("spawn"));
 		Plugin.callEvent(new GameLoadEvent(this));
@@ -121,6 +127,11 @@ public class HungerGame implements Comparable<HungerGame> {
 			}
 
 		}
+                
+                if(!itemsets.isEmpty()) {
+                    section.set("itemsets", itemsets);
+                }
+                
 		section.set("enabled", enabled);
 		if (getSpawn() != null) section.set("spawn", Plugin.parseToString(getSpawn()));
 		
@@ -309,9 +320,9 @@ public class HungerGame implements Comparable<HungerGame> {
 	}
 
         public void fillInventory(Inventory inv) {
-            if(!randomChests.contains(inv)) {
+            if(!randomChests.contains(inv.getHolder())) {
                 Plugin.fillChest(inv, itemsets);
-                randomChests.add(inv);
+                randomChests.add(inv.getHolder());
             }
         }
         

--- a/src/main/java/com/randude14/hungergames/games/HungerGame.java
+++ b/src/main/java/com/randude14/hungergames/games/HungerGame.java
@@ -22,6 +22,7 @@ import com.randude14.hungergames.GameCountdown;
 import com.randude14.hungergames.GameManager;
 import com.randude14.hungergames.Plugin;
 import com.randude14.hungergames.api.event.*;
+import org.bukkit.inventory.Inventory;
 
 import org.bukkit.inventory.ItemStack;
 
@@ -41,6 +42,7 @@ public class HungerGame implements Comparable<HungerGame> {
 	private boolean isCounting;
 	private boolean isPaused;
 	private boolean enabled;
+        private List<Inventory> randomChests;
 
 	public HungerGame(String name) {
 		this.name = name;
@@ -56,6 +58,7 @@ public class HungerGame implements Comparable<HungerGame> {
 		setup = null;
 		itemsets = new ArrayList<String>();
 		enabled = true;
+                randomChests = new ArrayList<Inventory>();
 	}
 
 	public HungerGame(String name, String setup) {
@@ -305,6 +308,13 @@ public class HungerGame implements Comparable<HungerGame> {
 
 	}
 
+        public void fillInventory(Inventory inv) {
+            if(!randomChests.contains(inv)) {
+                Plugin.fillChest(inv, itemsets);
+                randomChests.add(inv);
+            }
+        }
+        
 	public void fillChests() {
 		for (int cntr = 0; cntr < chests.size(); cntr++) {
 			Location loc = chests.get(cntr);
@@ -312,7 +322,7 @@ public class HungerGame implements Comparable<HungerGame> {
 				continue;
 			}
 			Chest chest = (Chest) loc.getBlock().getState();
-			Plugin.fillChest(chest, itemsets);
+			Plugin.fillChest(chest.getInventory(), itemsets);
 		}
 
 	}
@@ -456,6 +466,7 @@ public class HungerGame implements Comparable<HungerGame> {
 		stats.clear();
 		spawnsTaken.clear();
 		readyToPlay.clear();
+                randomChests.clear();
 		isRunning = false;
 		isCounting = false;
 	}


### PR DESCRIPTION
When first opening a chest (or doublechest) the inventory is filled randomly from specified itemsets, next time its opened (same game) no filling is done.

Please note that teleportlistener is commented out because its currently not in working shape :?
